### PR TITLE
JLFP: Task-aware wss overhead charges (pythonic)

### DIFF
--- a/schedcat/overheads/jlfp.py
+++ b/schedcat/overheads/jlfp.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 from math import ceil, floor
+import heapq
 
 def charge_initial_load(oheads, taskset):
     """Increase WCET to reflect the cost of establishing a warm cache.
@@ -51,10 +52,10 @@ def charge_scheduling_overheads(oheads, num_cpus, dedicated_irq, taskset):
         return False
 
     n   = len(taskset)
-    wss = taskset.max_wss()
-
-    sched = 2 * (oheads.schedule(n) + oheads.ctx_switch(n)) \
-            + oheads.cache_affinity_loss(wss)
+    
+    cpmd = [(ti, oheads.cache_affinity_loss(ti.wss)) \
+                for ti in heapq.nlargest(2, taskset, lambda x: x.wss)]
+    sched = 2 * (oheads.schedule(n) + oheads.ctx_switch(n))
 
     irq_latency = oheads.release_latency(n)
 
@@ -66,9 +67,16 @@ def charge_scheduling_overheads(oheads, num_cpus, dedicated_irq, taskset):
         unscaled = 2 * cpre
 
     for ti in taskset:
+        tasksched = sched
+        if cpmd:
+            if ti != cpmd[0][0]:
+                tasksched += cpmd[0][1]
+            elif len(cpmd) > 1:
+                tasksched += cpmd[1][1]
+
         ti.period   -= irq_latency
         ti.deadline -= irq_latency
-        ti.cost      = ((ti.cost + sched) / uscale) + unscaled
+        ti.cost      = ((ti.cost + tasksched) / uscale) + unscaled
         if ti.density() > 1:
             return False
 


### PR DESCRIPTION
This is a pythonic approach for task-aware wss overhead charges, unlike my prior patch on the "prop/task-aware-wss" branch. It's O(n lg n) instead of O(n), but it is much more pythonic.  I will explore a native implementation for overhead charging, where efficiency can be addressed more effectively.

(commit description)
The JLFP overhead model currently charges the same max-wss CPMD
to all tasks of a task set, even if each task has a different
wss. Instead, each task should be charged the max-wss CPMD, except
for the task with the largest wss. This task should be charged
a CPMD for the second-greatest wss.
