### PR TITLE
Replace Python by Python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # default tools
-PYTHON ?= python
+PYTHON ?= python2
 SCONS  ?= scons
 ETAGS  ?= etags
 
@@ -38,7 +38,7 @@ TAGS:
 	find . -type f -and  -iname '*.py' | xargs ${ETAGS}
 	find cpp/include -type f -and  -iname '*.h' | xargs ${ETAGS} -a
 	find cpp/src -type f -and  -iname '*.cpp' | xargs ${ETAGS} -a
-	${ETAGS} -l python -a run_exp
+	${ETAGS} -l ${PYTHON} -a run_exp
 
 # Vim Tags
 tags:

--- a/native/Makefile
+++ b/native/Makefile
@@ -8,7 +8,7 @@
 # default: swig binary available in $PATH.
 SWIG     ?= swig
 # default: standard python in $PATH.
-PYTHON   ?= python
+PYTHON   ?= python2
 # default: assume GMP is installed in standard location.
 GMP_PATH ?= /usr
 

--- a/schedcat/generator/generator_emstada.py
+++ b/schedcat/generator/generator_emstada.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 """A taskset generator for experiments with real-time task sets
 

--- a/schedcat/mapping/binpack.py
+++ b/schedcat/mapping/binpack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2007,2008,2009, Bjoern B. Brandenburg <bbb [at] cs.unc.edu>
 #

--- a/schedcat/mapping/rollback.py
+++ b/schedcat/mapping/rollback.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2010,2011,2012 Bjoern B. Brandenburg <bbb [at] cs.unc.edu>
 #

--- a/schedcat/model/serialize.py
+++ b/schedcat/model/serialize.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import xml.etree.ElementTree as ET
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import unittest
 

--- a/tests/binpack.py
+++ b/tests/binpack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from __future__ import division
 


### PR DESCRIPTION
Ensure that the repository works out of the box on machines where python links
to Python 3 instead of Python 2. Since Python2 usually links to the latest
version of Python 2 library that is installed, this should not break anyone's
workflow.
Tested on: Arch Linux and Debian Stable.