### PR TITLE
Added Guan & Yi's RTA

### DIFF
--- a/schedcat/model/tasks.py
+++ b/schedcat/model/tasks.py
@@ -47,6 +47,13 @@ class SporadicTask(object):
         """
         return max(0, self.response_time - self.deadline)
 
+    def slack(self):
+        """Return this task's slack time.
+        Note: this function can only be called after some test
+        established a response time bound (response_time must be defined)!
+        """
+        return self.deadline - self.response_time
+
     def maxjobs(self, interval_length):
         """Compute the maximum number of jobs that can execute during
         some interval.

--- a/schedcat/model/tasks.py
+++ b/schedcat/model/tasks.py
@@ -208,3 +208,4 @@ class TaskSystem(list):
         """
          # assumption: lower id == higher priority
         return (task for task in self if task.id > upper.id)
+

--- a/schedcat/sched/edf/gy_rta.py
+++ b/schedcat/sched/edf/gy_rta.py
@@ -1,0 +1,166 @@
+"""
+Efficient Response Time Analysis for EDF Scheduling.
+
+This module implements RTA for EDF Scheduling as proposed by Nan Guan & Wang Yi
+in their paper
+
+"General and Efficient Response Time Analysis for EDF Scheduling", DATE 2014.
+"""
+
+from __future__ import division
+
+from math import floor
+
+def dbf_i(tsk, t):
+    """
+    Demand bound function for task tsk in time interval t.
+    """
+    # Based on the dbf used in Baruah's schedulability test
+    if t <= 0:
+        return 0
+    return max(0, (int(floor((t - tsk.deadline) / tsk.period)) + 1) * tsk.cost)
+
+def rbf_i(tsk, t):
+    """
+    Request bound function for task tsk in time interval t.
+    """
+    if t < 0:
+        return 0
+    return dbf_i(tsk, t + tsk.deadline)
+
+def dbf(tskset, t):
+    """
+    Demand bound function of the system with taskset tskset in time interval t.
+    """
+    if t <= 0:
+        return 0
+    demand = 0
+    for tsk in tskset:
+        demand += dbf_i(tsk, t)
+    return demand
+
+def rbf(tskset, t):
+    """
+    Request bound function of the system with taskset tskset in time interval t.
+    """
+    if t < 0:
+        return 0
+    request = 0
+    for tsk in tskset:
+        request += rbf_i(tsk, t)
+    return request
+
+def sbf_uniprocessor(t):
+    """
+    Supply bound function of the system in time interval t for a uniprocessor.
+    """
+    return t
+
+def sbf_inverse_uniprocessor(x):
+    """
+    Pseudo inverse of the supply bound function for a uniprocessor.
+    """
+    return x
+
+def find_L_prime(tskset, sbf):
+    """
+    Returns L' at which rbf(L') <= sbf(L').
+    """
+    l = 0
+    while True:
+        if(rbf(tskset, l) <= sbf(l)):
+            return l
+        l += 1
+
+def find_L(tskset, sbf):
+    """
+    Returns L defined in the paper, L = L' + max(D_i)
+    """
+    return find_L_prime(tskset, sbf) + max(tsk.deadline for tsk in tskset)
+
+def delta_values(tskset, sbf):
+    """
+    Yields valid values of delta as required by the proposed algorithms.
+    """
+    L = find_L(tskset, sbf)
+    delta = min(tsk.deadline for tsk in tskset)
+    while delta <= L:
+        for tsk in tskset:
+            if delta % tsk.deadline == 0:
+                yield delta
+                break
+        delta += 1
+
+def approx_wcrt(tskset,
+                sbf = sbf_uniprocessor,
+                sbf_pseudo_inverse = sbf_inverse_uniprocessor):
+    """
+    Calculates worst-case response time by over-approximating slack bound
+    of all tasks in tskset as per Algorithm 1 in the paper.
+    NOTE: Sorts tskset using sort_by_deadline()
+    """
+    if tskset.utilization() > 1:
+        return False # tskset is not EDF Schedulable
+    tskset.sort_by_deadline()
+
+    s = [float("inf")] * len(tskset)
+    i = 0
+    delta = tskset[0].deadline
+    for delta in delta_values(tskset, sbf):
+        if i >= len(tskset)-1:
+            break
+        if delta >= tskset[i+1].deadline:
+            i += 1
+        s[i] = min(s[i], delta - sbf_pseudo_inverse(dbf(tskset, delta)))
+    for i in xrange(len(tskset)-1, -1, -1):
+        tskset[i].response_time = tskset[i].deadline - s[i]
+        if i == 0: break
+        s[i-1] = min(s[i], s[i-1])
+
+def mbf_i(tsk, delta, gamma):
+    """
+    Mixed bound function for task tsk with parameters delta and gamma.
+    """
+    return min(dbf_i(tsk, delta), rbf_i(tsk, gamma))
+
+def mbf(tskset, delta, gamma):
+    """
+    Mixed bound function of the system with taskset tskset with parameters
+    delta and gamma.
+    """
+    mixed = 0
+    for tsk in tskset:
+        mixed += mbf_i(tsk, delta, gamma)
+    return mixed
+
+def exact_wcrt(tskset,
+               sbf = sbf_uniprocessor,
+               sbf_pseudo_inverse = sbf_inverse_uniprocessor):
+    """
+    Calculates worst-case response time of all tasks in tskset by computing
+    exact slack bound as per Algorithm 2 in the paper.
+    NOTE: Sorts tskset using sort_by_deadline()
+    """
+    if tskset.utilization() > 1:
+        return False # tskset is not EDF schedulable
+    tskset.sort_by_deadline()
+
+    s = [float("inf")] * len(tskset)
+    i = 0
+    delta = tskset[0].deadline
+    for delta in delta_values(tskset, sbf):
+        if i >= len(tskset)-1:
+            break
+        if delta >= tskset[i+1].deadline:
+            i += 1
+        if delta - sbf_pseudo_inverse(dbf(tskset, delta)) < s[i]:
+            gamma_old = 0
+            gamma_new = sbf_pseudo_inverse(mbf(tskset, delta, 0))
+            while gamma_new != gamma_old:
+                gamma_old = gamma_new
+                gamma_new = sbf_pseudo_inverse(mbf(tskset, delta, gamma_old))
+            s[i] = min(s[i], delta - gamma_new)
+    for i in xrange(len(tskset)-1, -1, -1):
+        tskset[i].response_time = tskset[i].deadline - s[i]
+        if i == 0: break
+        s[i-1] = min(s[i], s[i-1])

--- a/tests/edf.py
+++ b/tests/edf.py
@@ -12,6 +12,7 @@ import schedcat.sched.edf.da as da
 import schedcat.sched.edf.ffdbf as ffdbf
 import schedcat.sched.edf.gfb as gfb
 import schedcat.sched.edf.rta as rta
+import schedcat.sched.edf.gy_rta as gy_rta
 import schedcat.sched.edf as edf
 
 import schedcat.sched as sched
@@ -187,3 +188,53 @@ class Test_QPA(unittest.TestCase):
             tasks.SporadicTask(1113, 83000, deadline=10683),
             ])
         self.assertFalse(qpa.is_schedulable(sched.get_native_taskset(ts2)))
+
+class Test_gy_rta(unittest.TestCase):
+    def setUp(self):
+        self.ts1 = tasks.TaskSystem([tasks.SporadicTask(3,12), tasks.SporadicTask(2,4)])
+        self.ts2 = tasks.TaskSystem([tasks.SporadicTask(3,12), tasks.SporadicTask(2,3), tasks.SporadicTask(2,4)])
+        self.ts3 = tasks.TaskSystem([tasks.SporadicTask(2,9), tasks.SporadicTask(3,12), tasks.SporadicTask(2,4)])
+        self.ts4 = tasks.TaskSystem([tasks.SporadicTask(1,4), tasks.SporadicTask(1,12), tasks.SporadicTask(3,16)])
+        self.ts5 = tasks.TaskSystem([tasks.SporadicTask(1,4), tasks.SporadicTask(2,4)])
+
+    def test_approx_wcrt(self):
+        gy_rta.approx_wcrt(self.ts1)
+        self.assertEqual(self.ts1[0].response_time, 2)
+        self.assertEqual(self.ts1[1].response_time, 9)
+
+        self.assertFalse(gy_rta.approx_wcrt(self.ts2))
+
+        gy_rta.approx_wcrt(self.ts3)
+        self.assertEqual(self.ts3[0].response_time, 3)
+        self.assertEqual(self.ts3[1].response_time, 8)
+        self.assertEqual(self.ts3[2].response_time, 11)
+
+        gy_rta.approx_wcrt(self.ts4)
+        self.assertEqual(self.ts4[0].response_time, 1)
+        self.assertEqual(self.ts4[1].response_time, 4)
+        self.assertEqual(self.ts4[2].response_time, 8)
+
+        gy_rta.approx_wcrt(self.ts5)
+        self.assertEqual(self.ts5[0].response_time, 3)
+        self.assertEqual(self.ts5[1].response_time, 3)
+
+    def test_exact_wcrt(self):
+        gy_rta.exact_wcrt(self.ts1)
+        self.assertEqual(self.ts1[0].response_time, 2)
+        self.assertEqual(self.ts1[1].response_time, 7)
+
+        self.assertFalse(gy_rta.exact_wcrt(self.ts2))
+
+        gy_rta.exact_wcrt(self.ts3)
+        self.assertEqual(self.ts3[0].response_time, 3)
+        self.assertEqual(self.ts3[1].response_time, 8)
+        self.assertEqual(self.ts3[2].response_time, 11)
+
+        gy_rta.exact_wcrt(self.ts4)
+        self.assertEqual(self.ts4[0].response_time, 1)
+        self.assertEqual(self.ts4[1].response_time, 2)
+        self.assertEqual(self.ts4[2].response_time, 6)
+
+        gy_rta.exact_wcrt(self.ts5)
+        self.assertEqual(self.ts5[0].response_time, 3)
+        self.assertEqual(self.ts5[1].response_time, 3)

--- a/tests/edf.py
+++ b/tests/edf.py
@@ -196,6 +196,8 @@ class Test_gy_rta(unittest.TestCase):
         self.ts3 = tasks.TaskSystem([tasks.SporadicTask(2,9), tasks.SporadicTask(3,12), tasks.SporadicTask(2,4)])
         self.ts4 = tasks.TaskSystem([tasks.SporadicTask(1,4), tasks.SporadicTask(1,12), tasks.SporadicTask(3,16)])
         self.ts5 = tasks.TaskSystem([tasks.SporadicTask(1,4), tasks.SporadicTask(2,4)])
+        self.ts6 = tasks.TaskSystem([tasks.SporadicTask(2,5,4), tasks.SporadicTask(3,6,5)])
+        self.ts7 = tasks.TaskSystem([tasks.SporadicTask(2,4,3), tasks.SporadicTask(3,12,10), tasks.SporadicTask(2,9,7)])
 
     def test_approx_wcrt(self):
         gy_rta.approx_wcrt(self.ts1)
@@ -218,6 +220,15 @@ class Test_gy_rta(unittest.TestCase):
         self.assertEqual(self.ts5[0].response_time, 3)
         self.assertEqual(self.ts5[1].response_time, 3)
 
+        gy_rta.approx_wcrt(self.ts6)
+        self.assertEqual(self.ts6[0].response_time, 4)
+        self.assertEqual(self.ts6[1].response_time, 5) 
+
+        gy_rta.approx_wcrt(self.ts7)
+        self.assertEqual(self.ts7[0].response_time, 3)
+        self.assertEqual(self.ts7[1].response_time, 7)
+        self.assertEqual(self.ts7[2].response_time, 10)
+
     def test_exact_wcrt(self):
         gy_rta.exact_wcrt(self.ts1)
         self.assertEqual(self.ts1[0].response_time, 2)
@@ -238,3 +249,13 @@ class Test_gy_rta(unittest.TestCase):
         gy_rta.exact_wcrt(self.ts5)
         self.assertEqual(self.ts5[0].response_time, 3)
         self.assertEqual(self.ts5[1].response_time, 3)
+
+        gy_rta.exact_wcrt(self.ts6)
+        self.assertEqual(self.ts6[0].response_time, 4)
+        self.assertEqual(self.ts6[1].response_time, 5)
+
+        gy_rta.exact_wcrt(self.ts7)
+        self.assertEqual(self.ts7[0].response_time, 3)
+        self.assertEqual(self.ts7[1].response_time, 7)
+        self.assertEqual(self.ts7[2].response_time, 10)
+


### PR DESCRIPTION
schedcat/sched/edf/gy_rta.py contains the new code for the analysis proposed by Nan Guan & Wang Yi.
schedcat/model/tasks.py has a new method to compute slack. 
5 unit tests added for gy_rta.py.
 
Note that sbf and sbf_pseudo_inverse functions are defaulted to the uniprocessor case unless the user defines his/her own versions.

Please do suggest possible modifications or additions.

Thanks.